### PR TITLE
Add markdown editor page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+.pnp.cjs
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# turbo
+.turbo

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,94 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #0b1021;
+  color: #e5e7eb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+.page {
+  min-height: 100vh;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.page__header h1 {
+  margin: 0 0 8px;
+  font-size: 2rem;
+}
+
+.page__header p {
+  margin: 0;
+  color: #cfd4e1;
+}
+
+.editor {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+  align-items: stretch;
+}
+
+.editor__pane {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #1f2937;
+  border-radius: 10px;
+  background: #111827;
+  min-height: 420px;
+}
+
+.editor__pane-header {
+  padding: 12px 14px;
+  border-bottom: 1px solid #1f2937;
+  font-weight: 600;
+  background: #0f172a;
+  color: #e5e7eb;
+}
+
+.editor__textarea {
+  flex: 1;
+  width: 100%;
+  padding: 14px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  resize: vertical;
+}
+
+.editor__textarea:focus {
+  outline: 2px solid #3b82f6;
+  outline-offset: -2px;
+}
+
+.editor__preview {
+  padding: 14px;
+  color: #e5e7eb;
+}
+
+.editor__preview pre {
+  background: #0b1021;
+  border-radius: 6px;
+  padding: 12px;
+  overflow: auto;
+}
+
+.editor__preview code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+.editor__preview a {
+  color: #60a5fa;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Markdown Editor",
+  description: "Simple Markdown editor with live preview",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+const initialMarkdown = `# Markdown プレビュー
+
+左側のエリアに Markdown を入力すると、このプレビューがリアルタイムに更新されます。
+
+## サンプル
+- **太字** や *斜体* のスタイル
+- [リンク](https://nextjs.org)
+- コードブロック:
+
+\`\`\`ts
+const greeting = "Hello Markdown";
+console.log(greeting);
+\`\`\`
+`;
+
+export default function HomePage() {
+  const [markdown, setMarkdown] = useState(initialMarkdown);
+
+  return (
+    <main className="page">
+      <header className="page__header">
+        <h1>Markdown Editor</h1>
+        <p>Type Markdown on the left to see a live preview on the right.</p>
+      </header>
+      <section className="editor">
+        <label className="editor__pane">
+          <div className="editor__pane-header">Markdown Input</div>
+          <textarea
+            className="editor__textarea"
+            value={markdown}
+            onChange={(event) => setMarkdown(event.target.value)}
+            aria-label="Markdown input"
+          />
+        </label>
+        <div className="editor__pane">
+          <div className="editor__pane-header">Preview</div>
+          <div className="editor__preview">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{markdown}</ReactMarkdown>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "codex-poc",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "15.0.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "react-markdown": "9.0.3",
+    "remark-gfm": "4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "22.7.4",
+    "@types/react": "18.3.7",
+    "@types/react-dom": "18.3.0",
+    "eslint": "8.57.1",
+    "eslint-config-next": "15.0.0",
+    "typescript": "5.6.3"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.mjs",
+    "**/*.cjs"
+  ],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up a minimal Next.js 15 App Router project structure with TypeScript configuration and global styling
- implement a client-side markdown editor with live preview using react-markdown and remark-gfm on the root page
- add supporting project metadata and configuration files for building and linting

## Testing
- npm install *(fails: registry access returned 403 Forbidden)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691ed3b2bf208324ba6bd443b0e3571f)