### PR TITLE
Add Mermaid editor and preview

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -40,13 +40,19 @@ body {
   align-items: stretch;
 }
 
+.editor__stack {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
 .editor__pane {
   display: flex;
   flex-direction: column;
   border: 1px solid #1f2937;
   border-radius: 10px;
   background: #111827;
-  min-height: 420px;
+  min-height: 220px;
 }
 
 .editor__pane-header {
@@ -91,4 +97,19 @@ body {
 
 .editor__preview a {
   color: #60a5fa;
+}
+
+.mermaid-preview {
+  min-height: 320px;
+}
+
+.mermaid-preview svg {
+  width: 100%;
+  height: auto;
+}
+
+.mermaid-error {
+  color: #fca5a5;
+  margin: 0;
+  padding: 0 14px 12px;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import mermaid from "mermaid";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -19,29 +20,101 @@ console.log(greeting);
 \`\`\`
 `;
 
+const initialMermaid = `sequenceDiagram
+  participant User
+  participant App as Markdown/Mermaid App
+  participant Renderer as Mermaid Renderer
+
+  User->>App: Mermaid テキストを入力
+  App-->>Renderer: Mermaid の描画をリクエスト
+  Renderer-->>App: SVG を返却
+  App-->>User: Mermaid プレビューを表示`;
+
 export default function HomePage() {
   const [markdown, setMarkdown] = useState(initialMarkdown);
+  const [mermaidText, setMermaidText] = useState(initialMermaid);
+  const [mermaidError, setMermaidError] = useState<string | null>(null);
+  const mermaidContainerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    mermaid.initialize({ startOnLoad: false, theme: "dark" });
+  }, []);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const renderMermaid = async () => {
+      if (!mermaidContainerRef.current) return;
+
+      try {
+        setMermaidError(null);
+        const { svg } = await mermaid.render(
+          `mermaid-diagram-${Date.now()}`,
+          mermaidText
+        );
+
+        if (!isMounted) return;
+
+        mermaidContainerRef.current.innerHTML = svg;
+      } catch (error) {
+        console.error("Failed to render mermaid diagram", error);
+        if (!isMounted) return;
+
+        if (mermaidContainerRef.current) {
+          mermaidContainerRef.current.innerHTML = "";
+        }
+        setMermaidError("Mermaid の描画に失敗しました");
+      }
+    };
+
+    renderMermaid();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [mermaidText]);
 
   return (
     <main className="page">
       <header className="page__header">
-        <h1>Markdown Editor</h1>
-        <p>Type Markdown on the left to see a live preview on the right.</p>
+        <h1>Markdown & Mermaid Editor</h1>
+        <p>Type Markdown and Mermaid on the left to see live previews on the right.</p>
       </header>
       <section className="editor">
-        <label className="editor__pane">
-          <div className="editor__pane-header">Markdown Input</div>
-          <textarea
-            className="editor__textarea"
-            value={markdown}
-            onChange={(event) => setMarkdown(event.target.value)}
-            aria-label="Markdown input"
-          />
-        </label>
-        <div className="editor__pane">
-          <div className="editor__pane-header">Preview</div>
-          <div className="editor__preview">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{markdown}</ReactMarkdown>
+        <div className="editor__stack">
+          <label className="editor__pane">
+            <div className="editor__pane-header">Markdown Input</div>
+            <textarea
+              className="editor__textarea"
+              value={markdown}
+              onChange={(event) => setMarkdown(event.target.value)}
+              aria-label="Markdown input"
+            />
+          </label>
+          <label className="editor__pane">
+            <div className="editor__pane-header">Mermaid Input</div>
+            <textarea
+              className="editor__textarea"
+              value={mermaidText}
+              onChange={(event) => setMermaidText(event.target.value)}
+              aria-label="Mermaid input"
+            />
+          </label>
+        </div>
+
+        <div className="editor__stack">
+          <div className="editor__pane">
+            <div className="editor__pane-header">Markdown プレビュー</div>
+            <div className="editor__preview">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                {markdown}
+              </ReactMarkdown>
+            </div>
+          </div>
+          <div className="editor__pane">
+            <div className="editor__pane-header">Mermaid プレビュー</div>
+            <div className="editor__preview mermaid-preview" ref={mermaidContainerRef} />
+            {mermaidError && <p className="mermaid-error">{mermaidError}</p>}
           </div>
         </div>
       </section>

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "next": "15.0.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "mermaid": "10.9.1",
     "react-markdown": "9.0.3",
     "remark-gfm": "4.0.0"
   },


### PR DESCRIPTION
## Summary
- add a Mermaid input pane and preview alongside the existing Markdown editor
- render Mermaid diagrams client-side with initialization, live updates, and error handling
- update styling to separate Markdown and Mermaid areas and add Mermaid dependency

## Testing
- not run (npm install blocked by registry 403 while attempting to add mermaid)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691ed67d87008324ab25119e9e96fdf3)