### PR TITLE
Add local storage for markdown entries

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,16 @@ import mermaid from "mermaid";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
+type MarkdownItem = {
+  id: string;
+  title: string;
+  markdown: string;
+  mermaid: string;
+  createdAt: string;
+};
+
+const STORAGE_KEY = "markdown_samples";
+
 const initialMarkdown = `# Markdown プレビュー
 
 左側のエリアに Markdown を入力すると、このプレビューがリアルタイムに更新されます。
@@ -34,10 +44,27 @@ export default function HomePage() {
   const [markdown, setMarkdown] = useState(initialMarkdown);
   const [mermaidText, setMermaidText] = useState(initialMermaid);
   const [mermaidError, setMermaidError] = useState<string | null>(null);
+  const [title, setTitle] = useState("");
+  const [items, setItems] = useState<MarkdownItem[]>([]);
+  const [statusMessage, setStatusMessage] = useState("");
   const mermaidContainerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     mermaid.initialize({ startOnLoad: false, theme: "dark" });
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const storedItems = localStorage.getItem(STORAGE_KEY);
+    if (storedItems) {
+      try {
+        const parsed: MarkdownItem[] = JSON.parse(storedItems);
+        setItems(parsed);
+      } catch (error) {
+        console.error("Failed to parse stored markdown items", error);
+      }
+    }
   }, []);
 
   useEffect(() => {
@@ -74,12 +101,64 @@ export default function HomePage() {
     };
   }, [mermaidText]);
 
+  const saveItemsToStorage = (nextItems: MarkdownItem[]) => {
+    setItems(nextItems);
+    if (typeof window !== "undefined") {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(nextItems));
+    }
+  };
+
+  const handleSave = () => {
+    const now = new Date().toLocaleString();
+    const itemTitle = title.trim() || "無題";
+    const newItem: MarkdownItem = {
+      id: crypto.randomUUID(),
+      title: itemTitle,
+      markdown,
+      mermaid: mermaidText,
+      createdAt: now,
+    };
+
+    const nextItems = [newItem, ...items];
+    saveItemsToStorage(nextItems);
+    setStatusMessage("保存しました");
+    setTimeout(() => setStatusMessage(""), 2000);
+  };
+
+  const handleDelete = (id: string) => {
+    const filtered = items.filter((item) => item.id !== id);
+    saveItemsToStorage(filtered);
+  };
+
+  const handleLoad = (item: MarkdownItem) => {
+    setTitle(item.title);
+    setMarkdown(item.markdown);
+    setMermaidText(item.mermaid);
+  };
+
   return (
     <main className="page">
       <header className="page__header">
         <h1>Markdown & Mermaid Editor</h1>
         <p>Type Markdown and Mermaid on the left to see live previews on the right.</p>
       </header>
+      <section className="save-panel">
+        <label className="save-panel__field">
+          <span className="save-panel__label">タイトル</span>
+          <input
+            type="text"
+            className="save-panel__input"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="無題"
+            aria-label="タイトル"
+          />
+        </label>
+        <button className="save-panel__button" type="button" onClick={handleSave}>
+          保存
+        </button>
+        {statusMessage && <span className="save-panel__status">{statusMessage}</span>}
+      </section>
       <section className="editor">
         <div className="editor__stack">
           <label className="editor__pane">
@@ -117,6 +196,36 @@ export default function HomePage() {
             {mermaidError && <p className="mermaid-error">{mermaidError}</p>}
           </div>
         </div>
+      </section>
+      <section className="saved-list">
+        <h2>保存済みの Markdown</h2>
+        {items.length === 0 ? (
+          <p className="saved-list__empty">保存された Markdown はありません。</p>
+        ) : (
+          <ul className="saved-list__items">
+            {items.map((item) => (
+              <li key={item.id} className="saved-list__item">
+                <button
+                  className="saved-list__item-body"
+                  type="button"
+                  onClick={() => handleLoad(item)}
+                  aria-label={`${item.title} を読み込む`}
+                >
+                  <div className="saved-list__title">{item.title}</div>
+                  <div className="saved-list__date">{item.createdAt}</div>
+                </button>
+                <button
+                  className="saved-list__delete"
+                  type="button"
+                  onClick={() => handleDelete(item.id)}
+                  aria-label={`${item.title} を削除`}
+                >
+                  削除
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
       </section>
     </main>
   );


### PR DESCRIPTION
## Summary
- add localStorage-backed saving for markdown and mermaid content with titles and timestamps
- display saved entries with load and delete actions to manage stored markdown snippets
- provide save controls with status messaging to give feedback on persisted content

## Testing
- npm run lint *(fails: `next` command unavailable because dependencies could not be installed in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691edba01d38832482952b1788c86f54)